### PR TITLE
Listing + Trading

### DIFF
--- a/internal/app/http/controller/trading_handler.go
+++ b/internal/app/http/controller/trading_handler.go
@@ -49,10 +49,10 @@ func (th *tradingHandler) signupPage() func(http.ResponseWriter, *http.Request) 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Check if the business has the status of "accepted".
 		business, err := BusinessHandler.FindByUserID(r.Header.Get("userID"))
-		if err != nil || business.Status != constant.Business.Accepted {
+		/*if err != nil || business.Status != constant.Business.Accepted {
 			http.Redirect(w, r, "/", http.StatusFound)
 			return
-		}
+		}*/
 		user, err := UserHandler.FindByID(r.Header.Get("userID"))
 		if err != nil {
 			http.Redirect(w, r, "/", http.StatusFound)

--- a/internal/app/http/controller/user_handler.go
+++ b/internal/app/http/controller/user_handler.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"encoding/json"
 	"net/http"
 	"sync"
@@ -180,7 +181,9 @@ func (u *userHandler) registerHandler() func(http.ResponseWriter, *http.Request)
 			}
 		}()
 
-		http.Redirect(w, r, "/", http.StatusFound)
+		submitURL := r.FormValue("submit")
+		//fmt.Println("MY BLOODY URL: ", submitURL)
+		http.Redirect(w, r, submitURL, http.StatusFound)
 	}
 }
 

--- a/internal/app/http/controller/user_handler.go
+++ b/internal/app/http/controller/user_handler.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"fmt"
+	//"fmt"
 	"encoding/json"
 	"net/http"
 	"sync"

--- a/web/template/signup.html
+++ b/web/template/signup.html
@@ -101,14 +101,16 @@
             </div>
         </div>
         <div class="g-recaptcha" style="margin: 2em 0;" data-sitekey={{.RecaptchaSitekey}}></div>
-        </p>Your directory entry will be reviewed by the OCN Team and we will get in touch to let you know when it goes live. Your personal details will not be made public or shared with any third parties and you can cancel your listing at any time.</p>
-        <button class="ui primary button" name="submit" type="submit" value="/">
+        <p>Your directory entry will be reviewed by the OCN Team and we will get in touch to let you know when it goes live. Your personal details will not be made public or shared with any third parties and you can cancel your listing at any time.</p>
+
+        <button data-tooltip="This option will list your business on our directory" data-variation="tiny" class="ui primary button" name="submit" type="submit" value="/">
             Apply for Free Listing
         </button>
-        <button class="ui secondary button" name="submit" type="submit" value="/member-signup">
+        <button class="ui secondary button" data-tooltip="As well as listing you on the directory, this option will also allow you to trade with other members" data-variation="tiny" name="submit" type="submit" value="/member-signup">
             Also Apply for Trading Membership
         </button>
-        <a href="/" class="ui button">Cancel</a>
+        <a href="/" class="ui button" data-tooltip="Cancel the form entries" data-variation="tiny">Cancel</a>
+
     </div>
 </form>
 {{ end }}

--- a/web/template/signup.html
+++ b/web/template/signup.html
@@ -102,8 +102,11 @@
         </div>
         <div class="g-recaptcha" style="margin: 2em 0;" data-sitekey={{.RecaptchaSitekey}}></div>
         </p>Your directory entry will be reviewed by the OCN Team and we will get in touch to let you know when it goes live. Your personal details will not be made public or shared with any third parties and you can cancel your listing at any time.</p>
-        <button class="ui primary button">
-            Apply Now
+        <button class="ui primary button" name="submit" type="submit" value="/">
+            Apply for Free Listing
+        </button>
+        <button class="ui secondary button" name="submit" type="submit" value="/member-signup">
+            Also Apply for Trading Membership
         </button>
         <a href="/" class="ui button">Cancel</a>
     </div>

--- a/web/template/signup.html
+++ b/web/template/signup.html
@@ -103,11 +103,11 @@
         <div class="g-recaptcha" style="margin: 2em 0;" data-sitekey={{.RecaptchaSitekey}}></div>
         <p>Your directory entry will be reviewed by the OCN Team and we will get in touch to let you know when it goes live. Your personal details will not be made public or shared with any third parties and you can cancel your listing at any time.</p>
 
-        <button data-tooltip="This option will list your business on our directory" data-variation="tiny" class="ui primary button" name="submit" type="submit" value="/">
-            Apply for Free Listing
+        <button data-tooltip="This will save your details in the directory but you will not be able to trade in mutual credit" data-variation="tiny" class="ui primary button" name="submit" type="submit" value="/">
+            Save Application
         </button>
-        <button class="ui secondary button" data-tooltip="As well as listing you on the directory, this option will also allow you to trade with other members" data-variation="tiny" name="submit" type="submit" value="/member-signup">
-            Also Apply for Trading Membership
+        <button class="ui secondary button" data-tooltip="Save your details in the directory and apply to become a Trading member" data-variation="tiny" name="submit" type="submit" value="/member-signup">
+            Save and Continue
         </button>
         <a href="/" class="ui button" data-tooltip="Cancel the form entries" data-variation="tiny">Cancel</a>
 


### PR DESCRIPTION
These changes add a button to the signup page, which also lets signees go to the /member-signup URL.

The solution is a bit hacky - to get it to work, I've commented out some code in _trading_handler.go_ which checks to see if the business has a status of "Accepted". Better might have been to add an extra status of some kind, but _Business.Status_ appears to be spread across many parts of the codebase, so adding a new status made me kinda nervous. 

I don't know what the side effects of my change are. For example, does commenting out the check of _Business.Status_ in _trading_handler.go_ impact other code? I'm also unsure how to set the site emailing up on my dev' environment, so I presume 2 emails go out, 1 for the listing request and one for the trading request? 

Anyway, the changes are quite minimal - just a few lines in _signup.html_, _user_handler.go_, and those commented out lines in _trading_handler.go_. If there are unwanted side effects, perhaps someone can use my stuff and make it work?